### PR TITLE
Add Middle School Project Helper page

### DIFF
--- a/pages/6_Middle_school_project_helper.py
+++ b/pages/6_Middle_school_project_helper.py
@@ -1,0 +1,38 @@
+from openai import OpenAI
+import streamlit as st
+
+with st.sidebar:
+    openai_api_key = st.text_input("OpenAI API Key", key="project_helper_api_key", type="password")
+    "[Get an OpenAI API key](https://platform.openai.com/account/api-keys)"
+    "[View the source code](https://github.com/streamlit/llm-examples/blob/main/pages/6_Middle_school_project_helper.py)"
+    "[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/streamlit/llm-examples?quickstart=1)"
+
+st.title("🧑‍🎓 Middle School Project Helper")
+st.caption("💡 A chatbot for brainstorming project ideas")
+
+if "messages" not in st.session_state:
+    st.session_state["messages"] = [
+        {
+            "role": "assistant",
+            "content": (
+                "Hi there! I'm here to help you find an interesting topic for your middle school project. "
+                "What subjects or hobbies do you enjoy?"
+            ),
+        }
+    ]
+
+for msg in st.session_state.messages:
+    st.chat_message(msg["role"]).write(msg["content"])
+
+if prompt := st.chat_input():
+    if not openai_api_key:
+        st.info("Please add your OpenAI API key to continue.")
+        st.stop()
+
+    client = OpenAI(api_key=openai_api_key)
+    st.session_state.messages.append({"role": "user", "content": prompt})
+    st.chat_message("user").write(prompt)
+    response = client.chat.completions.create(model="gpt-3.5-turbo", messages=st.session_state.messages)
+    msg = response.choices[0].message.content
+    st.session_state.messages.append({"role": "assistant", "content": msg})
+    st.chat_message("assistant").write(msg)


### PR DESCRIPTION
## Summary
- add a helper chatbot page for brainstorming middle school project ideas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849ef0c8a14832a990b9d05a5df3096