### PR TITLE
Fix summary button persistence

### DIFF
--- a/pages/6_Middle_school_project_helper.py
+++ b/pages/6_Middle_school_project_helper.py
@@ -45,7 +45,11 @@ if st.session_state.get("summary"):
     st.write("### Final Topic")
     st.write(st.session_state["summary"])
 
-if st.session_state.get("summary") is None and st.button("I'm excited about this topic"):
+summary_button_placeholder = st.empty()
+if (
+    st.session_state.get("summary") is None
+    and summary_button_placeholder.button("I'm excited about this topic", key="excited_button")
+):
     if not openai_api_key:
         st.info("Please add your OpenAI API key to continue.")
         st.stop()
@@ -64,5 +68,6 @@ if st.session_state.get("summary") is None and st.button("I'm excited about this
     )
     summary = summary_response.choices[0].message.content
     st.session_state["summary"] = summary
+    summary_button_placeholder.empty()
     st.write("### Final Topic")
     st.write(summary)


### PR DESCRIPTION
## Summary
- keep the final topic button in a persistent placeholder

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849f72f5800832aae202fffa5c100fa